### PR TITLE
Expose only user-defined types

### DIFF
--- a/impl/src/main/java/org/jboss/forge/furnace/container/guice/modules/GuiceContainerModule.java
+++ b/impl/src/main/java/org/jboss/forge/furnace/container/guice/modules/GuiceContainerModule.java
@@ -19,16 +19,15 @@ import org.jboss.forge.furnace.addons.AddonRegistry;
 import org.jboss.forge.furnace.container.guice.Service;
 import org.jboss.forge.furnace.event.EventManager;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.google.inject.matcher.Matchers;
+import com.google.inject.PrivateModule;
 
 /**
  * Default {@link Module} implementation
  * 
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
-public class GuiceContainerModule extends AbstractModule
+public class GuiceContainerModule extends PrivateModule
 {
    private final Furnace furnace;
    private final AddonRegistry addonRegistry;
@@ -50,12 +49,6 @@ public class GuiceContainerModule extends AbstractModule
       bind(Addon.class).toInstance(addon);
 
       bindServices();
-      bindImported();
-   }
-
-   private void bindImported()
-   {
-      bindListener(Matchers.any(), new ServiceTypeListener(addonRegistry));
    }
 
    @SuppressWarnings("unchecked")
@@ -84,6 +77,7 @@ public class GuiceContainerModule extends AbstractModule
                   String line = sc.nextLine();
                   Class serviceType = classLoader.loadClass(line);
                   bind(serviceType).toConstructor(serviceType.getConstructor());
+                  expose(serviceType);
                }
             }
             catch (Exception e)

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonRegistryTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonRegistryTest.java
@@ -7,8 +7,11 @@
 
 package org.jboss.forge.furnace.container.guice.service;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -27,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Module;
 
 /**
@@ -56,5 +60,19 @@ public class AddonRegistryTest
       Assert.assertThat(service.isAmbiguous(), is(false));
       Assert.assertThat(service.isUnsatisfied(), is(false));
       Assert.assertThat(service.get(), notNullValue());
+   }
+
+   @Test
+   public void testExportedTypes() throws Exception
+   {
+      Set<Class<?>> exportedTypes = addonRegistry.getExportedTypes();
+
+      Set<Class<?>> expectedTypes = Sets.newHashSet(
+               MockInterface.class,
+               MockService.class,
+               AddonRegistryTest.class
+      );
+
+      Assert.assertThat(exportedTypes, equalTo(expectedTypes));
    }
 }


### PR DESCRIPTION
By default, Guice will register some default types (i.e. Stage, Injector and even `java.util.logging.Logger`). Since we use `getAllBindings()` in GuiceServiceRegistry, we have to make sure that we don't export them. Also, we bind some Furnace-related classes (AddonRegistry, Addon, Furnace, etc), so we don't want to expose them as well.

This change will ensure that we don't export what we shouldn't export.

I also added a test for it to track such unexpected exports.
