### PR TITLE
Force explicit bindings in tests to avoid false-positives

### DIFF
--- a/tests/src/main/java/org/jboss/forge/furnace/container/guice/mock/services/ConsumerModule.java
+++ b/tests/src/main/java/org/jboss/forge/furnace/container/guice/mock/services/ConsumerModule.java
@@ -18,6 +18,6 @@ public class ConsumerModule extends AbstractModule
    @Override
    protected void configure()
    {
-      bind(AbstractBaseConsumer.class).to(ConcreteConsumer.class);
+      bind(ConcreteConsumer.class);
    }
 }

--- a/tests/src/main/java/org/jboss/forge/furnace/container/guice/mock/services/ExplicitBindingsModule.java
+++ b/tests/src/main/java/org/jboss/forge/furnace/container/guice/mock/services/ExplicitBindingsModule.java
@@ -1,0 +1,13 @@
+package org.jboss.forge.furnace.container.guice.mock.services;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+public class ExplicitBindingsModule implements Module
+{
+   @Override
+   public void configure(Binder binder)
+   {
+      binder.requireExplicitBindings();
+   }
+}

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/event/EventTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/event/EventTest.java
@@ -21,6 +21,7 @@ import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.forge.furnace.container.guice.Service;
 import org.jboss.forge.furnace.container.guice.mock.event.MockEventModule;
 import org.jboss.forge.furnace.container.guice.mock.event.MockEventListener;
+import org.jboss.forge.furnace.container.guice.mock.services.ExplicitBindingsModule;
 import org.jboss.forge.furnace.event.EventManager;
 import org.jboss.forge.furnace.event.PostStartup;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,8 +43,8 @@ public class EventTest
    public static AddonArchive getDeployment()
    {
       return ShrinkWrap.create(AddonArchive.class)
-               .addClasses(MockEventModule.class, MockEventListener.class)
-               .addAsServiceProvider(Module.class, MockEventModule.class)
+               .addClasses(MockEventListener.class)
+               .addAsServiceProviderAndClasses(Module.class, MockEventModule.class, ExplicitBindingsModule.class)
                .addAsServiceProvider(Service.class, EventTest.class);
    }
 

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonRegistryTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonRegistryTest.java
@@ -24,6 +24,7 @@ import org.jboss.forge.furnace.container.guice.Service;
 import org.jboss.forge.furnace.container.guice.mock.MockInterface;
 import org.jboss.forge.furnace.container.guice.mock.MockModule;
 import org.jboss.forge.furnace.container.guice.mock.MockService;
+import org.jboss.forge.furnace.container.guice.mock.services.ExplicitBindingsModule;
 import org.jboss.forge.furnace.services.Imported;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
@@ -48,8 +49,8 @@ public class AddonRegistryTest
    public static AddonArchive getDeployment()
    {
       return ShrinkWrap.create(AddonArchive.class)
-               .addClasses(MockInterface.class, MockService.class, MockModule.class)
-               .addAsServiceProvider(Module.class, MockModule.class)
+               .addClasses(MockInterface.class, MockService.class)
+               .addAsServiceProviderAndClasses(Module.class, MockModule.class, ExplicitBindingsModule.class)
                .addAsServiceProvider(Service.class, AddonRegistryTest.class);
    }
 
@@ -70,8 +71,7 @@ public class AddonRegistryTest
       Set<Class<?>> expectedTypes = Sets.newHashSet(
                MockInterface.class,
                MockService.class,
-               AddonRegistryTest.class
-      );
+               AddonRegistryTest.class);
 
       Assert.assertThat(exportedTypes, equalTo(expectedTypes));
    }

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonServiceDifferentContainerTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonServiceDifferentContainerTest.java
@@ -19,6 +19,7 @@ import org.jboss.forge.furnace.container.guice.mock.services.AbstractBaseConsume
 import org.jboss.forge.furnace.container.guice.mock.services.ConcreteConsumer;
 import org.jboss.forge.furnace.container.guice.mock.services.ConsumerModule;
 import org.jboss.forge.furnace.container.guice.mock.services.ExportedService;
+import org.jboss.forge.furnace.container.guice.mock.services.ExplicitBindingsModule;
 import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
@@ -42,8 +43,7 @@ public class AddonServiceDifferentContainerTest
    {
       AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
                .addClass(ConcreteConsumer.class)
-               .addClass(ConsumerModule.class)
-               .addAsServiceProvider(Module.class, ConsumerModule.class)
+               .addAsServiceProviderAndClasses(Module.class, ConsumerModule.class, ExplicitBindingsModule.class)
                .addAsServiceProvider(Service.class, AddonServiceDifferentContainerTest.class)
                .addAsAddonDependencies(
                         AddonDependencyEntry.create("org.jboss.forge.furnace.container:guice"),

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonServiceInjectionTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/AddonServiceInjectionTest.java
@@ -18,6 +18,7 @@ import org.jboss.forge.furnace.container.guice.Service;
 import org.jboss.forge.furnace.container.guice.mock.services.AbstractBaseConsumer;
 import org.jboss.forge.furnace.container.guice.mock.services.ConcreteConsumer;
 import org.jboss.forge.furnace.container.guice.mock.services.ConsumerModule;
+import org.jboss.forge.furnace.container.guice.mock.services.ExplicitBindingsModule;
 import org.jboss.forge.furnace.container.guice.mock.services.ExportedService;
 import org.jboss.forge.furnace.container.guice.mock.services.ProducerModule;
 import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
@@ -44,8 +45,7 @@ public class AddonServiceInjectionTest
       AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
                .addClass(ConcreteConsumer.class)
                .addAsServiceProvider(Service.class, AddonServiceInjectionTest.class)
-               .addClass(ConsumerModule.class)
-               .addAsServiceProvider(Module.class, ConsumerModule.class)
+               .addAsServiceProviderAndClasses(Module.class, ConsumerModule.class, ExplicitBindingsModule.class)
                .addAsAddonDependencies(
                         AddonDependencyEntry.create("org.jboss.forge.furnace.container:guice"),
                         AddonDependencyEntry.create("dependency"));
@@ -58,8 +58,7 @@ public class AddonServiceInjectionTest
    {
       AddonArchive archive = ShrinkWrap.create(AddonArchive.class, "dependency.jar")
                .addClasses(AbstractBaseConsumer.class, ExportedService.class)
-               .addClass(ProducerModule.class)
-               .addAsServiceProvider(Module.class, ProducerModule.class)
+               .addAsServiceProviderAndClasses(Module.class, ProducerModule.class, ExplicitBindingsModule.class)
                .addAsAddonDependencies(
                         AddonDependencyEntry.create("org.jboss.forge.furnace.container:guice"));
 

--- a/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/ServiceInjectionTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/guice/service/ServiceInjectionTest.java
@@ -19,6 +19,7 @@ import org.jboss.forge.furnace.container.guice.Service;
 import org.jboss.forge.furnace.container.guice.mock.MockInterface;
 import org.jboss.forge.furnace.container.guice.mock.MockModule;
 import org.jboss.forge.furnace.container.guice.mock.MockService;
+import org.jboss.forge.furnace.container.guice.mock.services.ExplicitBindingsModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,8 +42,8 @@ public class ServiceInjectionTest
    public static AddonArchive getDeployment()
    {
       return ShrinkWrap.create(AddonArchive.class)
-               .addClasses(MockInterface.class, MockService.class, MockModule.class)
-               .addAsServiceProvider(Module.class, MockModule.class)
+               .addClasses(MockInterface.class, MockService.class)
+               .addAsServiceProviderAndClasses(Module.class, MockModule.class, ExplicitBindingsModule.class)
                .addAsServiceProvider(Service.class, ServiceInjectionTest.class);
    }
 


### PR DESCRIPTION
By default, Guice will do Just-in-time bindings if the binding is not defined in the module by instantiating an instance of the requested class. It might be fine for the users, but it's not for the test cases where we ensure that everything is binding as we expected it to be bound. 

With this change, we force Guice not to use JIT bindings to avoid false positives in the tests. 

It also highlights an issue in `ConsumerModule`.
